### PR TITLE
Fix Windows CI heredoc usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: maturin build --release --out dist
 
       - name: Install built wheel
+        shell: bash
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -109,6 +110,7 @@ jobs:
 
       - name: Extract version
         id: metadata
+        shell: bash
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -126,6 +128,7 @@ jobs:
         id: changelog
         env:
           VERSION: ${{ steps.metadata.outputs.version }}
+        shell: bash
         run: |
           python - <<'PY'
           from __future__ import annotations


### PR DESCRIPTION
## Summary
- ensure heredoc-based Python snippets run under bash so Windows builds can execute them

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d3fe44a9e4832e960f576f296d8808